### PR TITLE
Update

### DIFF
--- a/api/auth/router.py
+++ b/api/auth/router.py
@@ -1,7 +1,6 @@
 from fastapi import APIRouter, Depends
 from fastapi.security import OAuth2PasswordRequestForm
-
-from libs.dependencies import create_auth_response, crypt, jwt_guard
+from libs.dependencies import create_auth_response, crypt, user_tracking
 from libs.exceptions import AuthException
 from libs.utils import initialize_model, validate_google_user
 from model.auth import (AuthenticatedUser, FBLoginData, GoogleLoginData,
@@ -52,7 +51,7 @@ async def login_with_username_password(
 
 @router.get("/refresh-token", response_model=AuthResponse)
 async def refresh_token(
-    user: AuthenticatedUser = Depends(jwt_guard),
+    user: AuthenticatedUser = Depends(user_tracking),
     pg: Postgres = Depends(get_pg),
 ):
     if user.provider != "app":

--- a/api/image/router.py
+++ b/api/image/router.py
@@ -3,12 +3,11 @@ from typing import List, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, File, Form, UploadFile
-
 from libs.dependencies import jwt_guard, user_tracking
 from libs.exceptions import ImageException
 from libs.utils import fix_tags, make_storage_key, validate_image_file
 from model.auth import AuthenticatedUser
-from model.http import GetImageResponse, UploadImageResponse
+from model.http import FindImageResponse, UploadImageResponse
 from model.postgres import Image, TaggedImage
 from repository import Minio, Postgres, get_minio, get_pg
 
@@ -22,7 +21,7 @@ async def find_image_by_id(pg: Postgres, minio: Minio, image_id: UUID):
     tags = await pg.get_image_tags(image.id)
     url = minio.get_image(image.storage_key)
 
-    return GetImageResponse(**image.dict(), url=url, tags=tags)
+    return FindImageResponse(**image.dict(), url=url, tags=tags)
 
 
 async def find_images_by_tags_datetime(
@@ -33,7 +32,7 @@ async def find_images_by_tags_datetime(
     offset: int,
     pg: Postgres,
     minio: Minio,
-) -> List[GetImageResponse]:
+) -> List[FindImageResponse]:
     images = await pg.search_image_by_tags(
         tags,
         limit=limit,
@@ -47,7 +46,7 @@ async def find_images_by_tags_datetime(
     for img in images:
         url = minio.get_image(img.image.storage_key)
         tag_names = [t.name for t in img.tags]
-        resp = GetImageResponse(**img.image.dict(), url=url, tags=tag_names)
+        resp = FindImageResponse(**img.image.dict(), url=url, tags=tag_names)
         result.append(resp)
 
     return result
@@ -101,7 +100,7 @@ async def upload_image(
     )
 
 
-@router.get("/find", response_model=List[GetImageResponse])
+@router.get("/find", response_model=List[FindImageResponse])
 async def find_images(
     image_id: Optional[UUID] = None,
     tags: Optional[str] = None,

--- a/api/image/router.py
+++ b/api/image/router.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, File, Form, UploadFile
-from libs.dependencies import jwt_guard, user_tracking
+from libs.dependencies import user_tracking
 from libs.exceptions import ImageException
 from libs.utils import fix_tags, make_storage_key, validate_image_file
 from model.auth import AuthenticatedUser
@@ -57,7 +57,7 @@ router = APIRouter()
 
 @router.post("", response_model=UploadImageResponse)
 async def upload_image(
-    user: AuthenticatedUser = Depends(jwt_guard),
+    user: AuthenticatedUser = Depends(user_tracking),
     image: UploadFile = File(...),
     tags: str = Form(None),
     minio: Minio = Depends(get_minio),

--- a/api/image/router.py
+++ b/api/image/router.py
@@ -101,8 +101,8 @@ async def upload_image(
     )
 
 
-@router.get("/", response_model=List[GetImageResponse])
-async def get_specific_image(
+@router.get("/find", response_model=List[GetImageResponse])
+async def find_images(
     image_id: Optional[UUID] = None,
     tags: Optional[str] = None,
     from_time: datetime = datetime.fromtimestamp(0),

--- a/api/tags/router.py
+++ b/api/tags/router.py
@@ -1,6 +1,5 @@
 from fastapi import APIRouter, Depends
-
-from libs.dependencies import jwt_guard
+from libs.dependencies import user_tracking
 from libs.exceptions import TagException
 from model.auth import AuthenticatedUser
 from model.http import AddTagsRequest, AddTagsResponse
@@ -13,7 +12,7 @@ router = APIRouter()
 async def add_tags(
     payload: AddTagsRequest,
     pg: Postgres = Depends(get_pg),
-    _: AuthenticatedUser = Depends(jwt_guard),
+    _: AuthenticatedUser = Depends(user_tracking),
 ):
     if not payload.tags:
         raise TagException.INVALID_TAGS

--- a/model/http.py
+++ b/model/http.py
@@ -50,7 +50,7 @@ class UploadImageResponse(BaseModel):
     tags: List[str] = []
 
 
-class GetImageResponse(BaseModel):
+class FindImageResponse(BaseModel):
     id: UUID
     name: str
     created_at: datetime

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -2,9 +2,8 @@ import pytest
 import pytest_asyncio  # noqa
 from asyncpg import Connection
 from fastapi.testclient import TestClient
-from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
-
 from main import app
+from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
 from repository.metric_collector import Collections, MetricCollector
 from repository.minio import Minio
 from repository.postgres import Postgres
@@ -45,7 +44,6 @@ class API:
     refresh = "v1/auth/refresh-token"
 
     upload_image = "v1/image"
-    get_image = "v1/image/"
-    search_image = "v1/image/search"
+    find_images = "v1/image/find"
 
     add_tag = "v1/tag"

--- a/tests/test__api_image.py
+++ b/tests/test__api_image.py
@@ -4,7 +4,7 @@ from random import sample
 from uuid import uuid1
 
 from logzero import logger as log
-from model.http import AuthResponse, GetImageResponse, UploadImageResponse
+from model.http import AuthResponse, FindImageResponse, UploadImageResponse
 
 from .fixtures import API, pytestmark, setup  # noqa
 
@@ -83,7 +83,7 @@ async def test_image_upload(setup):  # noqa
     assert isinstance(data, list)
     assert len(data) == 1
 
-    image: GetImageResponse = GetImageResponse(**data[0])
+    image: FindImageResponse = FindImageResponse(**data[0])
     assert image.id == tagged.id
     assert image.name == image.name
     assert image.uploaded_by == auth.user_id
@@ -119,4 +119,4 @@ async def test_image_upload(setup):  # noqa
 
     assert len(data) == 3
     for item in data:
-        assert GetImageResponse(**item)
+        assert FindImageResponse(**item)

--- a/tests/test__api_image.py
+++ b/tests/test__api_image.py
@@ -4,7 +4,6 @@ from random import sample
 from uuid import uuid1
 
 from logzero import logger as log
-
 from model.http import AuthResponse, GetImageResponse, UploadImageResponse
 
 from .fixtures import API, pytestmark, setup  # noqa
@@ -73,10 +72,10 @@ async def test_image_upload(setup):  # noqa
     response = client.post(API.upload_image, headers=headers, files=invalid_files)
     assert response.status_code == 400
 
-    # Test get image by id
+    # Test find image by id
     tags = ["foo", "bar", "nono"]
     params = {"image_id": str(tagged.id)}
-    response = client.get(API.get_image, headers=headers, params=params)
+    response = client.get(API.find_images, headers=headers, params=params)
 
     assert response.status_code == 200
     log.info(image)
@@ -92,13 +91,13 @@ async def test_image_upload(setup):  # noqa
     assert image.url
     assert image.created_at
 
-    # Getting an invalid image id
+    # Test find invalid image using invalid id
     params = {"image_id": "invalid-id"}
-    response = client.get(API.get_image, params=params, headers=headers)
+    response = client.get(API.find_images, params=params, headers=headers)
     assert response.status_code == 422
 
     params = {"image_id": uuid1()}
-    response = client.get(API.get_image, params=params, headers=headers)
+    response = client.get(API.find_images, params=params, headers=headers)
     assert response.status_code == 404
 
     # Upload multi images:
@@ -111,9 +110,9 @@ async def test_image_upload(setup):  # noqa
             API.upload_image, headers=headers, data=data, files=files
         )
 
-    # search
+    # Find multi images using tags
     params = {"tags": "foo,bar,hello", "limit": 3}
-    response = client.get(API.get_image, headers=headers, params=params)
+    response = client.get(API.find_images, headers=headers, params=params)
     assert response.status_code == 200
     data = response.json()
     log.info(data)


### PR DESCRIPTION
- Rename API for getting/searching images from *v1/image* to *v1/image/find*
- Rename **GetImageResponse** to **FindImageResponse**
- Replace *jwt_guard* dependency with *user_tracking* to track api-consumers on all possible endpoints